### PR TITLE
Fix bug: status does not carry over when editing project

### DIFF
--- a/src/main/java/arb/logic/commands/project/EditProjectCommand.java
+++ b/src/main/java/arb/logic/commands/project/EditProjectCommand.java
@@ -30,6 +30,7 @@ import arb.model.client.predicates.NameContainsKeywordsPredicate;
 import arb.model.project.Deadline;
 import arb.model.project.Price;
 import arb.model.project.Project;
+import arb.model.project.Status;
 import arb.model.project.Title;
 import arb.model.tag.Tag;
 
@@ -142,6 +143,7 @@ public class EditProjectCommand extends Command {
         if (optionalUpdatedDeadline.isPresent()) {
             updatedDeadline = optionalUpdatedDeadline.get().orElse(null);
         }
+        Status status = projectToEdit.getStatus();
 
         Optional<Optional<Price>> optionalUpdatedPrice = editProjectDescriptor.getPrice();
         Price updatedPrice = projectToEdit.getPrice();
@@ -151,7 +153,7 @@ public class EditProjectCommand extends Command {
 
         Set<Tag> updatedTags = editProjectDescriptor.getTags().orElse(projectToEdit.getTags());
 
-        return new Project(updatedTitle, updatedDeadline, updatedPrice, updatedTags);
+        return new Project(updatedTitle, status, updatedDeadline, updatedPrice, updatedTags);
     }
 
     @Override
@@ -238,6 +240,7 @@ public class EditProjectCommand extends Command {
         public Optional<Title> getTitle() {
             return Optional.ofNullable(title);
         }
+
 
         public Optional<Optional<Deadline>> getDeadline() {
             return Optional.ofNullable(this.deadline);

--- a/src/main/java/arb/model/project/Project.java
+++ b/src/main/java/arb/model/project/Project.java
@@ -45,7 +45,23 @@ public class Project {
         this.deadline = Optional.ofNullable(deadline);
         this.price = Optional.ofNullable(price);
         this.tags.addAll(tags);
+
         this.status = new Status();
+        this.linkedClient = Optional.empty();
+    }
+
+    /**
+     * Contructs a {@code Project}.
+     * Only to be used when created a new edited {@code Project}.
+     */
+    public Project(Title title, Status status, Deadline deadline, Price price, Set<Tag> tags) {
+        requireAllNonNull(title, tags);
+        this.title = title;
+        this.status = status;
+        this.deadline = Optional.ofNullable(deadline);
+        this.price = Optional.ofNullable(price);
+        this.tags.addAll(tags);
+
         this.linkedClient = Optional.empty();
     }
 


### PR DESCRIPTION
Let's copy the status over to the new project created when running edit-project

Close #191 