### PR TITLE
Fix bug: end date of find-project can be before start date

### DIFF
--- a/src/main/java/arb/logic/commands/project/FindProjectCommand.java
+++ b/src/main/java/arb/logic/commands/project/FindProjectCommand.java
@@ -21,6 +21,8 @@ import arb.model.project.Project;
  */
 public class FindProjectCommand extends Command {
 
+    public static final String MESSAGE_END_BEFORE_START_ERROR = "End date cannot be before start date.";
+
     private static final String MAIN_COMMAND_WORD = "find-project";
     private static final String ALIAS_COMMAND_WORD = "fp";
     private static final Set<String> COMMAND_WORDS =

--- a/src/main/java/arb/logic/parser/project/FindProjectCommandParser.java
+++ b/src/main/java/arb/logic/parser/project/FindProjectCommandParser.java
@@ -107,6 +107,12 @@ public class FindProjectCommandParser implements Parser<FindProjectCommand> {
             endOfTimeframe = ParserUtil.parseDeadline(endString.get());
         }
 
+        if (startOfTimeframe != null && endOfTimeframe != null) {
+            if (endOfTimeframe.compareTo(startOfTimeframe) < 0) {
+                throw new ParseException(FindProjectCommand.MESSAGE_END_BEFORE_START_ERROR);
+            }
+        }
+
         // if at least one of the timeframe specifiers are present
         if (startString.isPresent() || endString.isPresent()) {
             predicates.add(new ProjectWithinTimeframePredicate(startOfTimeframe, endOfTimeframe));


### PR DESCRIPTION
Let's add a check to compare the dates and show an error if end is before start

Close #193 